### PR TITLE
docs: add docs directory for canonical package documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A lightweight, type-safe HTTP framework built exclusively for [Bun](https://bun.
 
 Part of the [Bunary](https://github.com/bunary-dev) ecosystem - a Bun-first backend platform inspired by Laravel.
 
+## Documentation
+
+Canonical documentation for this package lives in [`docs/index.md`](./docs/index.md).
+
 ## Features
 
 - 🚀 **Bun-native** - Uses `Bun.serve()` directly, no Node.js compatibility layer

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,32 @@
+# @bunary/http
+
+A lightweight, type-safe HTTP framework built exclusively for [Bun](https://bun.sh).
+
+Part of the [Bunary](https://github.com/bunary-dev) ecosystem — a Bun-first backend platform inspired by Laravel.
+
+## Installation
+
+```bash
+bun add @bunary/http
+```
+
+## Quickstart
+
+```ts
+import { createApp } from "@bunary/http";
+
+const app = createApp();
+
+app.get("/hello", () => ({ message: "Hello, Bun!" }));
+
+app.listen({ port: 3000 });
+```
+
+## Notes
+
+- This package depends on `@bunary/core`, but you only need to install `@bunary/http` (dependencies install transitively).
+
+## Requirements
+
+- Bun ≥ 1.0.0
+


### PR DESCRIPTION
## Summary
- Add `docs/index.md` as the canonical documentation entry for `@bunary/http`.
- Update the README to point to the `docs/` directory.

## Test plan
- N/A (documentation only)

Closes #23