### PR TITLE
feat: RequestContext.locals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to `@bunary/http` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.5] - 2026-01-28
+
+### Added
+
+- `RequestContext.locals` for per-request middleware state (isolated between concurrent requests)
+
 ## [0.0.4] - 2026-01-26
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bunary/http",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "HTTP routing and middleware for Bunary - a Bun-first backend framework inspired by Laravel",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/app.ts
+++ b/src/app.ts
@@ -139,6 +139,7 @@ export function createApp(): BunaryApp {
 			request,
 			params: match.params,
 			query: url.searchParams,
+			locals: {},
 		};
 
 		try {

--- a/src/types/requestContext.ts
+++ b/src/types/requestContext.ts
@@ -19,4 +19,18 @@ export interface RequestContext {
 	params: PathParams;
 	/** Query parameters from the URL search string */
 	query: URLSearchParams;
+	/**
+	 * Per-request storage for middleware and handlers.
+	 *
+	 * This object is **initialized per request** (never shared across requests).
+	 *
+	 * @example
+	 * ```ts
+	 * app.use(async (ctx, next) => {
+	 *   ctx.locals.userId = "123";
+	 *   return await next();
+	 * });
+	 * ```
+	 */
+	locals: Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary
- Adds `ctx.locals` to `RequestContext` as per-request storage for middleware/handlers.
- Initializes `locals` per request (no shared object across concurrent requests).
- Adds tests proving per-request isolation.

## Version
- Bumped `@bunary/http` to `0.0.5` and updated `CHANGELOG.md`.

Closes #22