### PR TITLE
fix: align query API with URLSearchParams implementation (Closes #17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to `@bunary/http` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.6] - 2026-01-29
+
+### Fixed
+
+- Aligned query parameter API with actual implementation (bug #17)
+  - Removed misleading `QueryParams` type export that didn't match runtime `URLSearchParams`
+  - Updated README examples to use `ctx.query.get()` and `ctx.query.getAll()` instead of destructuring
+  - Fixed `RequestContext` interface documentation to show `query: URLSearchParams`
+
+### Removed
+
+- `QueryParams` type export (was inconsistent with actual `URLSearchParams` runtime type)
+
 ## [0.0.5] - 2026-01-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -89,12 +89,23 @@ app.get('/posts/:postId/comments/:commentId', (ctx) => {
 
 ### Query Parameters
 
-Query parameters are parsed from the URL:
+Query parameters are accessed via `URLSearchParams` API:
 
 ```typescript
 app.get('/search', (ctx) => {
-  const { q, page, limit } = ctx.query;
+  const q = ctx.query.get('q');
+  const page = ctx.query.get('page');
+  const limit = ctx.query.get('limit');
   return { query: q, page, limit };
+});
+```
+
+For multi-value query parameters (e.g., `?tag=a&tag=b`), use `getAll()`:
+
+```typescript
+app.get('/filter', (ctx) => {
+  const tags = ctx.query.getAll('tag');
+  return { tags };
 });
 ```
 
@@ -106,7 +117,7 @@ Route handlers receive a `RequestContext` object:
 interface RequestContext {
   request: Request;  // Original Bun Request object
   params: Record<string, string>;  // Path parameters
-  query: Record<string, string>;   // Query parameters
+  query: URLSearchParams;  // Query parameters (use .get() and .getAll())
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bunary/http",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "HTTP routing and middleware for Bunary - a Bun-first backend framework inspired by Laravel",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,6 @@ export type {
 	HttpMethod,
 	Middleware,
 	PathParams,
-	QueryParams,
 	RequestContext,
 	Route,
 	RouteBuilder,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,7 +11,6 @@ export type { HandlerResponse } from "./handlerResponse.js";
 export type { HttpMethod } from "./httpMethod.js";
 export type { Middleware } from "./middleware.js";
 export type { PathParams } from "./pathParams.js";
-export type { QueryParams } from "./queryParams.js";
 export type { RequestContext } from "./requestContext.js";
 export type { Route } from "./route.js";
 export type { RouteBuilder } from "./routeBuilder.js";

--- a/src/types/queryParams.ts
+++ b/src/types/queryParams.ts
@@ -1,4 +1,0 @@
-/**
- * Query parameters parsed from the URL search string.
- */
-export type QueryParams = Record<string, string | string[]>;


### PR DESCRIPTION
This PR fixes the inconsistency between the query parameter API documentation/types and the actual implementation.

## Problem
- `RequestContext.query` is `URLSearchParams` (correct)
- `QueryParams` type was exported as `Record<string, string | string[]>` (incorrect)
- README showed destructuring example that doesn't work with URLSearchParams

## Changes
- ✅ Removed misleading `QueryParams` type export
- ✅ Deleted unused `queryParams.ts` file
- ✅ Updated README query examples to use `ctx.query.get()` and `ctx.query.getAll()`
- ✅ Fixed `RequestContext` interface documentation to show `query: URLSearchParams`
- ✅ Updated CHANGELOG

## Acceptance Criteria ✅
- ✅ Public types are consistent: removed `QueryParams` export that implied different runtime shape
- ✅ README query examples match the actual API (using `.get()` and `.getAll()`)
- ✅ Tests already cover multi-value query usage with `getAll` (verified existing test)

## Testing
- ✅ All 118 tests pass
- ✅ Linting passes
- ✅ Type checking passes

## Usage

```ts
// Single value
const q = ctx.query.get('q');

// Multi-value (e.g., ?tag=a&tag=b)
const tags = ctx.query.getAll('tag');
```

Closes #17