### PR TITLE
feat: add createApp({ basePath }) option to prefix all routes (Closes #18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to `@bunary/http` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.8] - 2026-01-29
+
+### Added
+
+- `createApp({ basePath })` option to prefix all routes (feature #18)
+  - Base path is automatically normalized (leading slash added, trailing slash removed)
+  - Composes correctly with route groups: `basePath + group prefix + route path`
+  - Included in `app.route()` URL generation for named routes
+  - Useful when mounting the app behind a reverse proxy
+
 ## [0.0.7] - 2026-01-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -40,15 +40,26 @@ app.listen({ port: 3000 });
 
 ## API
 
-### `createApp()`
+### `createApp(options?)`
 
 Creates a new Bunary application instance.
 
 ```typescript
 import { createApp } from '@bunary/http';
 
+// Without basePath
 const app = createApp();
+
+// With basePath (prefixes all routes)
+const apiApp = createApp({ basePath: '/api' });
+apiApp.get('/users', () => ({})); // Matches /api/users
 ```
+
+**Options:**
+- `basePath` - Optional base path prefix for all routes (useful when mounting behind a reverse proxy)
+  - Automatically normalized (leading slash added, trailing slash removed)
+  - Composes with route groups: `basePath + group prefix + route path`
+  - Included in `app.route()` URL generation
 
 ### Route Registration
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bunary/http",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "HTTP routing and middleware for Bunary - a Bun-first backend framework inspired by Laravel",
   "type": "module",
   "main": "./dist/index.js",

--- a/tests/basePath.test.ts
+++ b/tests/basePath.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+import { createApp } from "../src/index.js";
+
+describe("basePath", () => {
+	test("createApp({ basePath }) prefixes all routes", async () => {
+		const app = createApp({ basePath: "/api" });
+		app.get("/users", () => ({ users: [] }));
+
+		const response = await app.fetch(new Request("http://localhost/api/users"));
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({ users: [] });
+	});
+
+	test("basePath with trailing slash is normalized", async () => {
+		const app = createApp({ basePath: "/api/" });
+		app.get("/users", () => ({ users: [] }));
+
+		const response = await app.fetch(new Request("http://localhost/api/users"));
+
+		expect(response.status).toBe(200);
+	});
+
+	test("basePath without leading slash is normalized", async () => {
+		const app = createApp({ basePath: "api" });
+		app.get("/users", () => ({ users: [] }));
+
+		const response = await app.fetch(new Request("http://localhost/api/users"));
+
+		expect(response.status).toBe(200);
+	});
+
+	test("routes without basePath do not match prefixed paths", async () => {
+		const app = createApp({ basePath: "/api" });
+		app.get("/users", () => ({ users: [] }));
+
+		const response = await app.fetch(new Request("http://localhost/users"));
+
+		expect(response.status).toBe(404);
+	});
+
+	test("basePath composes with route groups", async () => {
+		const app = createApp({ basePath: "/api" });
+		app.group("/v1", (router) => {
+			router.get("/users", () => ({ users: [] }));
+		});
+
+		const response = await app.fetch(new Request("http://localhost/api/v1/users"));
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({ users: [] });
+	});
+
+	test("basePath composes with nested route groups", async () => {
+		const app = createApp({ basePath: "/api" });
+		app.group("/v1", (router) => {
+			router.group("/admin", (nestedRouter) => {
+				nestedRouter.get("/users", () => ({ users: [] }));
+			});
+		});
+
+		const response = await app.fetch(new Request("http://localhost/api/v1/admin/users"));
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({ users: [] });
+	});
+
+	test("app.route() includes basePath in generated URLs", () => {
+		const app = createApp({ basePath: "/api" });
+		app.get("/users/:id", () => ({})).name("users.show");
+
+		const url = app.route("users.show", { id: 123 });
+
+		expect(url).toBe("/api/users/123");
+	});
+
+	test("app.route() includes basePath with groups", () => {
+		const app = createApp({ basePath: "/api" });
+		app.group("/v1", (router) => {
+			router.get("/users/:id", () => ({})).name("users.show");
+		});
+
+		const url = app.route("users.show", { id: 123 });
+
+		expect(url).toBe("/api/v1/users/123");
+	});
+
+	test("basePath with root path", async () => {
+		const app = createApp({ basePath: "/" });
+		app.get("/users", () => ({ users: [] }));
+
+		const response = await app.fetch(new Request("http://localhost/users"));
+
+		expect(response.status).toBe(200);
+	});
+
+	test("basePath works with path parameters", async () => {
+		const app = createApp({ basePath: "/api" });
+		app.get("/users/:id", (ctx) => ({ id: ctx.params.id }));
+
+		const response = await app.fetch(new Request("http://localhost/api/users/123"));
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({ id: "123" });
+	});
+
+	test("basePath works with optional path parameters", async () => {
+		const app = createApp({ basePath: "/api" });
+		app.get("/posts/:id?/comments", (ctx) => ({ id: ctx.params.id }));
+
+		const response1 = await app.fetch(new Request("http://localhost/api/posts/123/comments"));
+		const response2 = await app.fetch(new Request("http://localhost/api/posts/comments"));
+
+		expect(response1.status).toBe(200);
+		expect(await response1.json()).toEqual({ id: "123" });
+		expect(response2.status).toBe(200);
+		expect(await response2.json()).toEqual({ id: undefined });
+	});
+});


### PR DESCRIPTION
This PR adds support for a `basePath` option in `createApp()` to prefix all routes, making it easier to mount the app under a subpath (e.g., behind a reverse proxy).

## Problem
`AppOptions` defined `basePath` but `createApp()` didn't support it. This makes it difficult to mount apps under a subpath without rewriting every route or using group wrappers.

## Changes
- ✅ `createApp({ basePath })` now accepts optional `AppOptions`
- ✅ Base path is automatically normalized (leading slash added, trailing slash removed)
- ✅ Base path is applied to all route registrations (`get/post/put/delete/patch`)
- ✅ Base path composes correctly with route groups (`basePath + group prefix + route path`)
- ✅ `app.route()` URL generation includes basePath
- ✅ Added 11 comprehensive tests covering all scenarios
- ✅ Updated README with basePath documentation
- ✅ Updated CHANGELOG and bumped version to 0.0.8

## Acceptance Criteria ✅
- ✅ `createApp({ basePath })` is supported and documented
- ✅ All route registration helpers respect basePath
- ✅ `app.route(...)` includes basePath in generated URLs
- ✅ Tests cover basePath with normal routes, grouped routes, and named routes

## Testing
- ✅ All 135 tests pass (including 11 new basePath tests)
- ✅ Linting passes
- ✅ Type checking passes

## Usage

```ts
// Without basePath
const app = createApp();
app.get("/users", () => ({})); // Matches /users

// With basePath
const apiApp = createApp({ basePath: "/api" });
apiApp.get("/users", () => ({})); // Matches /api/users

// BasePath composes with groups
apiApp.group("/v1", (router) => {
  router.get("/users", () => ({})); // Matches /api/v1/users
});

// URL generation includes basePath
apiApp.get("/users/:id", () => ({})).name("users.show");
const url = apiApp.route("users.show", { id: 123 }); // "/api/users/123"
```

Closes #18