### PR TITLE
fix: proper HEAD/OPTIONS handling + Allow header for 405 (Closes #16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to `@bunary/http` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.9] - 2026-01-29
+
+### Fixed
+
+- Proper HEAD and OPTIONS request handling (bug #16)
+  - HEAD requests to GET routes now return 200 with empty body (preserves headers and status)
+  - OPTIONS requests return 204 with `Allow` header listing permitted methods
+  - 405 Method Not Allowed responses now include `Allow` header
+  - Route constraints are respected when determining allowed methods
+
 ## [0.0.8] - 2026-01-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -132,6 +132,48 @@ interface RequestContext {
 }
 ```
 
+### HTTP Method Handling
+
+#### HEAD Requests
+
+HEAD requests are automatically handled for GET routes. They return the same status code and headers as the corresponding GET request, but with an empty body:
+
+```typescript
+app.get('/users', () => ({ users: [] }));
+
+// HEAD /users returns 200 with empty body
+// Preserves all headers from GET handler
+```
+
+#### OPTIONS Requests
+
+OPTIONS requests return `204 No Content` with an `Allow` header listing all permitted methods for the path:
+
+```typescript
+app.get('/users', () => ({}));
+app.post('/users', () => ({}));
+app.delete('/users', () => ({}));
+
+// OPTIONS /users returns:
+// Status: 204
+// Allow: DELETE, GET, POST
+```
+
+If no route matches the path, OPTIONS returns `404`.
+
+#### Method Not Allowed (405)
+
+When a path exists but the requested method is not allowed, the response includes an `Allow` header:
+
+```typescript
+app.get('/users', () => ({}));
+app.post('/users', () => ({}));
+
+// PUT /users returns:
+// Status: 405 Method Not Allowed
+// Allow: GET, POST
+```
+
 ### Response Handling
 
 Handlers can return various types - they're automatically serialized:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bunary/http",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "HTTP routing and middleware for Bunary - a Bun-first backend framework inspired by Laravel",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/routes/find.ts
+++ b/src/routes/find.ts
@@ -48,3 +48,25 @@ export function hasMatchingPath(routes: Route[], path: string): boolean {
 		return checkConstraints(params, route.constraints);
 	});
 }
+
+/**
+ * Get all allowed HTTP methods for a given path.
+ * Respects route constraints when determining matches.
+ *
+ * @param routes - All registered routes
+ * @param path - Path to check
+ * @returns Array of allowed HTTP methods
+ */
+export function getAllowedMethods(routes: Route[], path: string): string[] {
+	const methods = new Set<string>();
+	for (const route of routes) {
+		if (route.pattern.test(path)) {
+			const params = extractParams(path, route);
+			// Only include method if constraints pass
+			if (checkConstraints(params, route.constraints)) {
+				methods.add(route.method);
+			}
+		}
+	}
+	return Array.from(methods).sort();
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,3 +1,3 @@
 export { compilePattern, createRouteBuilder, wrapBuilderWithNamePrefix } from "./builder.js";
-export { findRoute, hasMatchingPath, type RouteMatch } from "./find.js";
+export { findRoute, getAllowedMethods, hasMatchingPath, type RouteMatch } from "./find.js";
 export { type AddRouteFn, createGroupRouter } from "./group.js";

--- a/tests/headOptions.test.ts
+++ b/tests/headOptions.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, test } from "bun:test";
+import { createApp } from "../src/index.js";
+
+describe("HEAD requests", () => {
+	test("HEAD request to GET route returns 200 with empty body", async () => {
+		const app = createApp();
+		app.get("/users", () => ({ users: [] }));
+
+		const response = await app.fetch(new Request("http://localhost/users", { method: "HEAD" }));
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("");
+		expect(response.headers.get("Content-Type")).toBe("application/json");
+	});
+
+	test("HEAD request preserves response headers from GET handler", async () => {
+		const app = createApp();
+		app.get("/users", () => {
+			return new Response(JSON.stringify({ users: [] }), {
+				headers: { "X-Custom-Header": "test" },
+			});
+		});
+
+		const response = await app.fetch(new Request("http://localhost/users", { method: "HEAD" }));
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("");
+		expect(response.headers.get("X-Custom-Header")).toBe("test");
+	});
+
+	test("HEAD request to non-existent route returns 404", async () => {
+		const app = createApp();
+		app.get("/users", () => ({ users: [] }));
+
+		const response = await app.fetch(new Request("http://localhost/posts", { method: "HEAD" }));
+
+		expect(response.status).toBe(404);
+	});
+
+	test("HEAD request to route with wrong method returns 405", async () => {
+		const app = createApp();
+		app.post("/users", () => ({ users: [] }));
+
+		const response = await app.fetch(new Request("http://localhost/users", { method: "HEAD" }));
+
+		expect(response.status).toBe(405);
+	});
+
+	test("HEAD request works with path parameters", async () => {
+		const app = createApp();
+		app.get("/users/:id", (ctx) => ({ id: ctx.params.id }));
+
+		const response = await app.fetch(new Request("http://localhost/users/123", { method: "HEAD" }));
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("");
+	});
+
+	test("HEAD request works with middleware", async () => {
+		const app = createApp();
+		app.use((ctx, next) => {
+			ctx.locals.test = "middleware";
+			return next();
+		});
+		app.get("/users", () => ({ users: [] }));
+
+		const response = await app.fetch(new Request("http://localhost/users", { method: "HEAD" }));
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("");
+	});
+
+	test("HEAD request preserves status code from GET handler", async () => {
+		const app = createApp();
+		app.get("/users", () => {
+			return new Response(JSON.stringify({ users: [] }), { status: 201 });
+		});
+
+		const response = await app.fetch(new Request("http://localhost/users", { method: "HEAD" }));
+
+		expect(response.status).toBe(201);
+		expect(await response.text()).toBe("");
+	});
+});
+
+describe("OPTIONS requests", () => {
+	test("OPTIONS request to existing route returns 204 with Allow header", async () => {
+		const app = createApp();
+		app.get("/users", () => ({ users: [] }));
+		app.post("/users", () => ({ created: true }));
+
+		const response = await app.fetch(new Request("http://localhost/users", { method: "OPTIONS" }));
+
+		expect(response.status).toBe(204);
+		const allowHeader = response.headers.get("Allow");
+		expect(allowHeader).toBeTruthy();
+		expect(allowHeader?.split(", ").sort()).toEqual(["GET", "POST"].sort());
+		expect(await response.text()).toBe("");
+	});
+
+	test("OPTIONS request includes all methods for a path", async () => {
+		const app = createApp();
+		app.get("/users", () => ({}));
+		app.post("/users", () => ({}));
+		app.put("/users", () => ({}));
+		app.delete("/users", () => ({}));
+		app.patch("/users", () => ({}));
+
+		const response = await app.fetch(new Request("http://localhost/users", { method: "OPTIONS" }));
+
+		expect(response.status).toBe(204);
+		const allowHeader = response.headers.get("Allow");
+		const methods = allowHeader?.split(", ").sort() || [];
+		expect(methods).toEqual(["DELETE", "GET", "PATCH", "POST", "PUT"]);
+	});
+
+	test("OPTIONS request to non-existent route returns 404", async () => {
+		const app = createApp();
+		app.get("/users", () => ({ users: [] }));
+
+		const response = await app.fetch(new Request("http://localhost/posts", { method: "OPTIONS" }));
+
+		expect(response.status).toBe(404);
+		expect(response.headers.get("Allow")).toBeNull();
+	});
+
+	test("OPTIONS request works with path parameters", async () => {
+		const app = createApp();
+		app.get("/users/:id", () => ({}));
+		app.put("/users/:id", () => ({}));
+
+		const response = await app.fetch(new Request("http://localhost/users/123", { method: "OPTIONS" }));
+
+		expect(response.status).toBe(204);
+		const allowHeader = response.headers.get("Allow");
+		expect(allowHeader?.split(", ").sort()).toEqual(["GET", "PUT"].sort());
+	});
+
+	test("OPTIONS request respects route constraints", async () => {
+		const app = createApp();
+		app.get("/users/:id", () => ({}))
+			.where("id", /^\d+$/);
+		app.get("/users/:id", () => ({}))
+			.where("id", /^[a-z]+$/);
+
+		// Only numeric constraint matches
+		const response1 = await app.fetch(
+			new Request("http://localhost/users/123", { method: "OPTIONS" }),
+		);
+		expect(response1.status).toBe(204);
+		const allow1 = response1.headers.get("Allow");
+		expect(allow1).toBe("GET");
+
+		// Only alphabetic constraint matches
+		const response2 = await app.fetch(
+			new Request("http://localhost/users/abc", { method: "OPTIONS" }),
+		);
+		expect(response2.status).toBe(204);
+		const allow2 = response2.headers.get("Allow");
+		expect(allow2).toBe("GET");
+	});
+});
+
+describe("405 Method Not Allowed with Allow header", () => {
+	test("405 response includes Allow header", async () => {
+		const app = createApp();
+		app.get("/users", () => ({ users: [] }));
+		app.post("/users", () => ({ created: true }));
+
+		const response = await app.fetch(new Request("http://localhost/users", { method: "PUT" }));
+
+		expect(response.status).toBe(405);
+		const allowHeader = response.headers.get("Allow");
+		expect(allowHeader).toBeTruthy();
+		expect(allowHeader?.split(", ").sort()).toEqual(["GET", "POST"].sort());
+	});
+
+	test("405 response includes all allowed methods", async () => {
+		const app = createApp();
+		app.get("/users", () => ({}));
+		app.post("/users", () => ({}));
+		app.delete("/users", () => ({}));
+
+		const response = await app.fetch(new Request("http://localhost/users", { method: "PUT" }));
+
+		expect(response.status).toBe(405);
+		const allowHeader = response.headers.get("Allow");
+		const methods = allowHeader?.split(", ").sort() || [];
+		expect(methods).toEqual(["DELETE", "GET", "POST"]);
+	});
+
+	test("405 response respects route constraints", async () => {
+		const app = createApp();
+		app.get("/users/:id", () => ({}))
+			.where("id", /^\d+$/);
+		app.post("/users/:id", () => ({}))
+			.where("id", /^\d+$/);
+
+		const response = await app.fetch(new Request("http://localhost/users/123", { method: "PUT" }));
+
+		expect(response.status).toBe(405);
+		const allowHeader = response.headers.get("Allow");
+		expect(allowHeader?.split(", ").sort()).toEqual(["GET", "POST"].sort());
+	});
+
+	test("405 response works with path parameters", async () => {
+		const app = createApp();
+		app.get("/users/:id", () => ({}));
+		app.delete("/users/:id", () => ({}));
+
+		const response = await app.fetch(new Request("http://localhost/users/123", { method: "POST" }));
+
+		expect(response.status).toBe(405);
+		const allowHeader = response.headers.get("Allow");
+		expect(allowHeader?.split(", ").sort()).toEqual(["DELETE", "GET"].sort());
+	});
+});


### PR DESCRIPTION
This PR fixes proper handling of HEAD and OPTIONS HTTP methods, and adds Allow headers to 405 responses.

## Problem
`HttpMethod` included `HEAD` and `OPTIONS`, but:
- HEAD requests to GET routes returned 405 instead of behaving like GET
- OPTIONS requests were not handled
- 405 responses lacked `Allow` header listing permitted methods

## Changes
- ✅ HEAD requests to GET routes now return 200 with empty body (preserves headers and status)
- ✅ OPTIONS requests return 204 with `Allow` header listing permitted methods
- ✅ 405 Method Not Allowed responses include `Allow` header
- ✅ Route constraints are respected when determining allowed methods
- ✅ Added `getAllowedMethods()` helper function
- ✅ Added 16 comprehensive tests covering all scenarios
- ✅ Updated README with HEAD/OPTIONS documentation
- ✅ Updated CHANGELOG and bumped version to 0.0.9

## Acceptance Criteria ✅
- ✅ `HEAD /existing-get-route` returns status 200 (or same status as GET) with no body
- ✅ `OPTIONS /existing-route` returns 204 and includes `Allow` header
- ✅ 405 responses include `Allow` header
- ✅ Tests cover HEAD, OPTIONS, and Allow header behavior

## Testing
- ✅ All 151 tests pass (including 16 new HEAD/OPTIONS tests)
- ✅ Linting passes
- ✅ Type checking passes

## Usage

```ts
const app = createApp();

app.get('/users', () => ({ users: [] }));

// HEAD /users returns 200 with empty body (preserves headers)
const headResponse = await app.fetch(new Request('http://localhost/users', { method: 'HEAD' }));

// OPTIONS /users returns 204 with Allow header
const optionsResponse = await app.fetch(new Request('http://localhost/users', { method: 'OPTIONS' }));
// Allow: GET

// PUT /users returns 405 with Allow header
const putResponse = await app.fetch(new Request('http://localhost/users', { method: 'PUT' }));
// Status: 405
// Allow: GET
```

Closes #16