### PR TITLE
chore: remove unused @bunary/core dependency (Closes #21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to `@bunary/http` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.11] - 2026-01-29
+
+### Removed
+
+- Removed unused `@bunary/core` dependency (chore #21)
+  - Package now has zero runtime dependencies
+  - Updated README and documentation to reflect this change
+
 ## [0.0.10] - 2026-01-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Canonical documentation for this package lives in [`docs/index.md`](./docs/index
 ## Features
 
 - 🚀 **Bun-native** - Uses `Bun.serve()` directly, no Node.js compatibility layer
-- 📦 **Zero dependencies** - Only depends on `@bunary/core`
+- 📦 **Zero dependencies** - No runtime dependencies
 - 🔒 **Type-safe** - Full TypeScript support with strict types
 - ⚡ **Fast** - Minimal overhead, direct routing
 - 🧩 **Simple API** - Chainable route registration with automatic JSON serialization

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ app.listen({ port: 3000 });
 
 ## Notes
 
-- This package depends on `@bunary/core`, but you only need to install `@bunary/http` (dependencies install transitively).
+- This package has zero runtime dependencies - just install `@bunary/http`.
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bunary/http",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "HTTP routing and middleware for Bunary - a Bun-first backend framework inspired by Laravel",
   "type": "module",
   "main": "./dist/index.js",
@@ -44,9 +44,7 @@
   "engines": {
     "bun": ">=1.0.0"
   },
-  "dependencies": {
-    "@bunary/core": "^0.0.2"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@biomejs/biome": "^2.3.13",
     "bun-types": "^1.0.0",


### PR DESCRIPTION
This PR removes the unused `@bunary/core` dependency from `@bunary/http`.

## Problem
`@bunary/http` listed `@bunary/core` as a dependency, but the codebase does not import it. This can confuse consumers and increases install footprint unnecessarily.

## Solution
- ✅ Removed `@bunary/core` from `package.json` dependencies
- ✅ Updated README to reflect zero dependencies (changed from "Only depends on @bunary/core" to "No runtime dependencies")
- ✅ Updated `docs/index.md` to remove mention of `@bunary/core`
- ✅ Package now truly has zero runtime dependencies

## Verification
- ✅ Verified no imports of `@bunary/core` exist in codebase
- ✅ All 175 tests pass
- ✅ Linting passes
- ✅ Type checking passes
- ✅ Updated CHANGELOG and bumped version to 0.0.11

## Impact
- Reduces install footprint
- Clarifies that the package has zero dependencies
- No runtime behavior changes

Closes #21