### PR TITLE
feat: body parsing helpers — ctx.json(), ctx.text(), ctx.formData()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to `@bunary/http` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-02-17
+
+### Added
+
+- Body parsing helpers on `RequestContext` — `ctx.json()`, `ctx.text()`, `ctx.formData()` (#51)
+  - `ctx.json<T>()` — parse JSON body with type inference, throws `BodyParseError` on malformed input
+  - `ctx.text()` — get request body as string
+  - `ctx.formData()` — parse multipart/URL-encoded form data, throws `BodyParseError` on malformed input
+  - `BodyParseError` class exported for catch-based error handling in handlers
+  - Thin wrappers around `Request` methods — no parsing framework, no validation, zero new dependencies
+
 ## [0.2.0] - 2026-02-15
 
 ### Added

--- a/docs/index.md
+++ b/docs/index.md
@@ -127,7 +127,7 @@ Register routes using chainable HTTP method helpers:
 app
   .get('/users', () => ({ users: [] }))
   .post('/users', async (ctx) => {
-    const body = await ctx.request.json();
+    const body = await ctx.json();
     return { id: 1, ...body };
   })
   .put('/users/:id', (ctx) => {
@@ -243,8 +243,60 @@ interface RequestContext<
   params: TParams;   // Path parameters (narrowed by route generic)
   query: URLSearchParams;  // Query parameters (use .get() and .getAll())
   locals: TLocals;   // Per-request storage (narrowed by createApp generic)
+
+  // Body parsing helpers
+  json<T = unknown>(): Promise<T>;     // Parse JSON body (throws BodyParseError)
+  text(): Promise<string>;             // Get body as string
+  formData(): Promise<FormData>;       // Parse form data (throws BodyParseError)
 }
 ```
+
+#### Body Parsing Helpers
+
+`ctx.json()`, `ctx.text()`, and `ctx.formData()` are thin wrappers around the underlying `Request` methods with improved error handling:
+
+```typescript
+// Parse JSON with type inference
+app.post('/users', async (ctx) => {
+  const body = await ctx.json<{ name: string; email: string }>();
+  return { id: 1, name: body.name, email: body.email };
+});
+
+// Get raw text body
+app.post('/webhooks', async (ctx) => {
+  const payload = await ctx.text();
+  return { received: payload.length };
+});
+
+// Parse form data
+app.post('/upload', async (ctx) => {
+  const form = await ctx.formData();
+  const name = form.get('name');
+  return { name };
+});
+```
+
+Malformed bodies throw `BodyParseError`, which you can catch for custom error responses:
+
+```typescript
+import { BodyParseError } from '@bunary/http';
+
+app.post('/users', async (ctx) => {
+  try {
+    return await ctx.json();
+  } catch (error) {
+    if (error instanceof BodyParseError) {
+      return new Response(
+        JSON.stringify({ error: error.message }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+    throw error;
+  }
+});
+```
+
+> The original `ctx.request` is still available for advanced use cases (e.g. streaming, `arrayBuffer()`, `blob()`).
 
 `TLocals` is set once via `createApp<TLocals>()` and flows to all handlers and middleware.
 `TParams` is set per-route via `app.get<TParams>()` and only affects that handler's `ctx.params`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -297,6 +297,7 @@ app.post('/users', async (ctx) => {
 ```
 
 > The original `ctx.request` is still available for advanced use cases (e.g. streaming, `arrayBuffer()`, `blob()`).
+> Note: per the Fetch API, the request body can only be consumed once. If middleware calls `ctx.json()`, `ctx.text()`, or `ctx.formData()`, the downstream handler cannot read the body again; instead, share the parsed data via `ctx.locals` or work with a cloned request if you need to access the body in multiple places.
 
 `TLocals` is set once via `createApp<TLocals>()` and flows to all handlers and middleware.
 `TParams` is set per-route via `app.get<TParams>()` and only affects that handler's `ctx.params`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bunary/http",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "HTTP routing and middleware for Bunary - a Bun-first backend framework inspired by Laravel",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,3 +1,4 @@
+import { createRequestContext } from "./context.js";
 import {
 	executeRoute,
 	handleError,
@@ -171,12 +172,7 @@ export function createApp<TLocals extends object = Record<string, unknown>>(
 		}
 
 		// Build request context
-		const ctx: RequestContext = {
-			request,
-			params: match.params,
-			query: url.searchParams,
-			locals: {},
-		};
+		const ctx: RequestContext = createRequestContext(request, match.params, url.searchParams);
 
 		try {
 			const response = await executeRoute(match, ctx, getMiddlewareChain);

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,0 +1,40 @@
+import { BodyParseError } from "./errors.js";
+import type { PathParams } from "./types/pathParams.js";
+import type { RequestContext } from "./types/requestContext.js";
+
+/**
+ * Create a RequestContext for a given request and params.
+ *
+ * Centralises context construction so that body helpers (`json`, `text`,
+ * `formData`) are available everywhere a `RequestContext` is built —
+ * including 404/405 handler contexts.
+ *
+ * @internal
+ */
+export function createRequestContext(
+	request: Request,
+	params: PathParams,
+	query: URLSearchParams,
+): RequestContext {
+	return {
+		request,
+		params,
+		query,
+		locals: {},
+		json: async <T = unknown>(): Promise<T> => {
+			try {
+				return (await request.json()) as T;
+			} catch (error) {
+				throw new BodyParseError("Failed to parse JSON body", error);
+			}
+		},
+		text: () => request.text(),
+		formData: async () => {
+			try {
+				return (await request.formData()) as unknown as FormData;
+			} catch (error) {
+				throw new BodyParseError("Failed to parse form data", error);
+			}
+		},
+	};
+}

--- a/src/context.ts
+++ b/src/context.ts
@@ -31,7 +31,7 @@ export function createRequestContext(
 		text: () => request.text(),
 		formData: async () => {
 			try {
-				return (await request.formData()) as unknown as FormData;
+				return await request.formData();
 			} catch (error) {
 				throw new BodyParseError("Failed to parse form data", error);
 			}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,37 @@
+/**
+ * Error thrown when request body parsing fails.
+ *
+ * Thrown by `ctx.json()` and `ctx.formData()` when the request body
+ * cannot be parsed. Handlers can catch this to return a custom 400 response.
+ *
+ * @example
+ * ```ts
+ * import { BodyParseError } from "@bunary/http";
+ *
+ * app.post("/users", async (ctx) => {
+ *   try {
+ *     const body = await ctx.json();
+ *     return { received: body };
+ *   } catch (error) {
+ *     if (error instanceof BodyParseError) {
+ *       return new Response(JSON.stringify({ error: error.message }), {
+ *         status: 400,
+ *         headers: { "Content-Type": "application/json" },
+ *       });
+ *     }
+ *     throw error;
+ *   }
+ * });
+ * ```
+ */
+export class BodyParseError extends Error {
+	override readonly name = "BodyParseError";
+
+	/** The underlying parse error, if available */
+	readonly cause?: unknown;
+
+	constructor(message: string, cause?: unknown) {
+		super(message);
+		this.cause = cause;
+	}
+}

--- a/src/handlers/methodNotAllowed.ts
+++ b/src/handlers/methodNotAllowed.ts
@@ -1,3 +1,4 @@
+import { createRequestContext } from "../context.js";
 import { toResponse } from "../response.js";
 import { getAllowedMethods } from "../routes/index.js";
 import type { AppOptions, RequestContext, Route } from "../types/index.js";
@@ -19,12 +20,7 @@ export async function handleMethodNotAllowed(
 ): Promise<Response> {
 	const url = new URL(request.url);
 	const allowedMethods = precomputed ?? getAllowedMethods(routes, path);
-	const methodNotAllowedCtx: RequestContext = {
-		request,
-		params: {},
-		query: url.searchParams,
-		locals: {},
-	};
+	const methodNotAllowedCtx: RequestContext = createRequestContext(request, {}, url.searchParams);
 	if (options?.onMethodNotAllowed) {
 		const result = await options.onMethodNotAllowed(methodNotAllowedCtx, allowedMethods);
 		const response = toResponse(result);

--- a/src/handlers/notFound.ts
+++ b/src/handlers/notFound.ts
@@ -1,3 +1,4 @@
+import { createRequestContext } from "../context.js";
 import { toResponse } from "../response.js";
 import type { AppOptions, RequestContext } from "../types/index.js";
 
@@ -11,12 +12,7 @@ export async function handleNotFound(
 	options?: AppOptions,
 ): Promise<Response> {
 	const url = new URL(request.url);
-	const notFoundCtx: RequestContext = {
-		request,
-		params: {},
-		query: url.searchParams,
-		locals: {},
-	};
+	const notFoundCtx: RequestContext = createRequestContext(request, {}, url.searchParams);
 	if (options?.onNotFound) {
 		const result = await options.onNotFound(notFoundCtx);
 		return toResponse(result);

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,8 +19,10 @@
  * @packageDocumentation
  */
 
-// Export app factory (to be implemented)
+// Export app factory
 export { createApp } from "./app.js";
+// Export error classes
+export { BodyParseError } from "./errors.js";
 // Export types
 export type {
 	AppOptions,

--- a/src/types/requestContext.ts
+++ b/src/types/requestContext.ts
@@ -47,4 +47,61 @@ export interface RequestContext<
 	 * ```
 	 */
 	locals: TLocals;
+
+	/**
+	 * Parse the request body as JSON.
+	 *
+	 * Thin wrapper around `request.json()` with error handling.
+	 * Throws `BodyParseError` if the body is not valid JSON.
+	 *
+	 * @typeParam T — Expected shape of the parsed JSON body
+	 * @returns The parsed JSON body
+	 * @throws {BodyParseError} If the body cannot be parsed as JSON
+	 *
+	 * @example
+	 * ```ts
+	 * app.post("/users", async (ctx) => {
+	 *   const body = await ctx.json<{ name: string }>();
+	 *   return { id: 1, name: body.name };
+	 * });
+	 * ```
+	 */
+	json: <T = unknown>() => Promise<T>;
+
+	/**
+	 * Get the request body as a string.
+	 *
+	 * Thin wrapper around `request.text()`.
+	 *
+	 * @returns The request body as text
+	 *
+	 * @example
+	 * ```ts
+	 * app.post("/echo", async (ctx) => {
+	 *   const text = await ctx.text();
+	 *   return { echo: text };
+	 * });
+	 * ```
+	 */
+	text: () => Promise<string>;
+
+	/**
+	 * Parse the request body as FormData.
+	 *
+	 * Thin wrapper around `request.formData()` with error handling.
+	 * Throws `BodyParseError` if the body cannot be parsed as form data.
+	 *
+	 * @returns The parsed FormData
+	 * @throws {BodyParseError} If the body cannot be parsed as form data
+	 *
+	 * @example
+	 * ```ts
+	 * app.post("/upload", async (ctx) => {
+	 *   const form = await ctx.formData();
+	 *   const name = form.get("name");
+	 *   return { name };
+	 * });
+	 * ```
+	 */
+	formData: () => Promise<FormData>;
 }

--- a/src/types/requestContext.ts
+++ b/src/types/requestContext.ts
@@ -103,5 +103,5 @@ export interface RequestContext<
 	 * });
 	 * ```
 	 */
-	formData: () => Promise<FormData>;
+	formData: () => ReturnType<Request["formData"]>;
 }

--- a/tests/bodyHelpers.test.ts
+++ b/tests/bodyHelpers.test.ts
@@ -309,5 +309,33 @@ describe("Body Parsing Helpers", () => {
 			expect(response.status).toBe(200);
 			expect(await response.json()).toEqual({ name: "Alice" });
 		});
+
+		test("fails when middleware consumes body before handler", async () => {
+			const app = createApp();
+
+			app.use(async (ctx, next) => {
+				// Middleware consumes the body before the handler
+				await ctx.json();
+				return await next();
+			});
+
+			app.post("/users", async (ctx) => {
+				// Second attempt to read body should fail per Fetch API spec
+				const body = await ctx.json();
+				return body;
+			});
+
+			const response = await app.fetch(
+				new Request("http://localhost/users", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ name: "Bob" }),
+				}),
+			);
+
+			// Document expected behavior when body is consumed multiple times:
+			// second read should result in a failure (e.g. 500 error)
+			expect(response.status).not.toBe(200);
+		});
 	});
 });

--- a/tests/bodyHelpers.test.ts
+++ b/tests/bodyHelpers.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, test } from "bun:test";
+import { createApp } from "../src/index.js";
+
+describe("Body Parsing Helpers", () => {
+	describe("ctx.json()", () => {
+		test("parses JSON body from POST request", async () => {
+			const app = createApp();
+			app.post("/users", async (ctx) => {
+				const body = await ctx.json();
+				return { received: body };
+			});
+
+			const response = await app.fetch(
+				new Request("http://localhost/users", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ name: "Alice", age: 30 }),
+				}),
+			);
+
+			expect(response.status).toBe(200);
+			expect(await response.json()).toEqual({
+				received: { name: "Alice", age: 30 },
+			});
+		});
+
+		test("returns typed result with generic parameter", async () => {
+			interface CreateUser {
+				name: string;
+				age: number;
+			}
+
+			const app = createApp();
+			app.post("/users", async (ctx) => {
+				const body = await ctx.json<CreateUser>();
+				// Type-level check: body.name and body.age should be accessible
+				return { name: body.name, age: body.age };
+			});
+
+			const response = await app.fetch(
+				new Request("http://localhost/users", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ name: "Bob", age: 25 }),
+				}),
+			);
+
+			expect(response.status).toBe(200);
+			expect(await response.json()).toEqual({ name: "Bob", age: 25 });
+		});
+
+		test("throws BodyParseError for invalid JSON", async () => {
+			const app = createApp();
+			app.post("/users", async (ctx) => {
+				const body = await ctx.json();
+				return { received: body };
+			});
+
+			const response = await app.fetch(
+				new Request("http://localhost/users", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: "not valid json{{{",
+				}),
+			);
+
+			// Default error handler returns 500; handler didn't catch the error
+			expect(response.status).toBe(500);
+		});
+
+		test("BodyParseError can be caught in handler for custom 400 response", async () => {
+			const { BodyParseError } = await import("../src/index.js");
+
+			const app = createApp();
+			app.post("/users", async (ctx) => {
+				try {
+					return await ctx.json();
+				} catch (error) {
+					if (error instanceof BodyParseError) {
+						return new Response(JSON.stringify({ error: error.message }), {
+							status: 400,
+							headers: { "Content-Type": "application/json" },
+						});
+					}
+					throw error;
+				}
+			});
+
+			const response = await app.fetch(
+				new Request("http://localhost/users", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: "not valid json",
+				}),
+			);
+
+			expect(response.status).toBe(400);
+			const data = (await response.json()) as { error: string };
+			expect(data.error).toContain("Failed to parse JSON body");
+		});
+
+		test("parses nested JSON objects", async () => {
+			const app = createApp();
+			app.post("/data", async (ctx) => {
+				return await ctx.json();
+			});
+
+			const nested = { user: { name: "Alice", roles: ["admin", "user"] } };
+			const response = await app.fetch(
+				new Request("http://localhost/data", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify(nested),
+				}),
+			);
+
+			expect(response.status).toBe(200);
+			expect(await response.json()).toEqual(nested);
+		});
+
+		test("parses JSON array body", async () => {
+			const app = createApp();
+			app.post("/items", async (ctx) => {
+				const items = await ctx.json();
+				return { items };
+			});
+
+			const response = await app.fetch(
+				new Request("http://localhost/items", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify([1, 2, 3]),
+				}),
+			);
+
+			expect(response.status).toBe(200);
+			expect(await response.json()).toEqual({ items: [1, 2, 3] });
+		});
+	});
+
+	describe("ctx.text()", () => {
+		test("returns request body as string", async () => {
+			const app = createApp();
+			app.post("/echo", async (ctx) => {
+				const text = await ctx.text();
+				return { echo: text };
+			});
+
+			const response = await app.fetch(
+				new Request("http://localhost/echo", {
+					method: "POST",
+					headers: { "Content-Type": "text/plain" },
+					body: "Hello, Bunary!",
+				}),
+			);
+
+			expect(response.status).toBe(200);
+			expect(await response.json()).toEqual({ echo: "Hello, Bunary!" });
+		});
+
+		test("returns empty string for empty body", async () => {
+			const app = createApp();
+			app.post("/echo", async (ctx) => {
+				const text = await ctx.text();
+				return { echo: text };
+			});
+
+			const response = await app.fetch(
+				new Request("http://localhost/echo", {
+					method: "POST",
+					body: "",
+				}),
+			);
+
+			expect(response.status).toBe(200);
+			expect(await response.json()).toEqual({ echo: "" });
+		});
+
+		test("returns raw JSON string without parsing", async () => {
+			const app = createApp();
+			app.post("/raw", async (ctx) => {
+				const text = await ctx.text();
+				return { raw: text };
+			});
+
+			const jsonBody = JSON.stringify({ key: "value" });
+			const response = await app.fetch(
+				new Request("http://localhost/raw", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: jsonBody,
+				}),
+			);
+
+			expect(response.status).toBe(200);
+			const data = (await response.json()) as { raw: string };
+			expect(data.raw).toBe(jsonBody);
+		});
+	});
+
+	describe("ctx.formData()", () => {
+		test("parses multipart form data", async () => {
+			const app = createApp();
+			app.post("/form", async (ctx) => {
+				const form = await ctx.formData();
+				return {
+					name: form.get("name"),
+					email: form.get("email"),
+				};
+			});
+
+			const formData = new FormData();
+			formData.append("name", "Alice");
+			formData.append("email", "alice@example.com");
+
+			const response = await app.fetch(
+				new Request("http://localhost/form", {
+					method: "POST",
+					body: formData,
+				}),
+			);
+
+			expect(response.status).toBe(200);
+			expect(await response.json()).toEqual({
+				name: "Alice",
+				email: "alice@example.com",
+			});
+		});
+
+		test("parses URL-encoded form data", async () => {
+			const app = createApp();
+			app.post("/form", async (ctx) => {
+				const form = await ctx.formData();
+				return {
+					name: form.get("name"),
+					email: form.get("email"),
+				};
+			});
+
+			const response = await app.fetch(
+				new Request("http://localhost/form", {
+					method: "POST",
+					headers: { "Content-Type": "application/x-www-form-urlencoded" },
+					body: "name=Bob&email=bob%40example.com",
+				}),
+			);
+
+			expect(response.status).toBe(200);
+			expect(await response.json()).toEqual({
+				name: "Bob",
+				email: "bob@example.com",
+			});
+		});
+
+		test("throws BodyParseError for invalid form data", async () => {
+			const { BodyParseError } = await import("../src/index.js");
+
+			const app = createApp();
+			app.post("/form", async (ctx) => {
+				try {
+					return await ctx.formData();
+				} catch (error) {
+					if (error instanceof BodyParseError) {
+						return new Response(JSON.stringify({ error: error.message }), {
+							status: 400,
+							headers: { "Content-Type": "application/json" },
+						});
+					}
+					throw error;
+				}
+			});
+
+			const response = await app.fetch(
+				new Request("http://localhost/form", {
+					method: "POST",
+					headers: { "Content-Type": "multipart/form-data; boundary=invalid" },
+					body: "this is not valid multipart data",
+				}),
+			);
+
+			expect(response.status).toBe(400);
+			const data = (await response.json()) as { error: string };
+			expect(data.error).toContain("Failed to parse form data");
+		});
+	});
+
+	describe("helpers work with middleware", () => {
+		test("body helpers are available after middleware runs", async () => {
+			const app = createApp();
+
+			app.use(async (ctx, next) => {
+				// Middleware runs before handler — helpers should still work
+				return await next();
+			});
+
+			app.post("/users", async (ctx) => {
+				const body = await ctx.json();
+				return body;
+			});
+
+			const response = await app.fetch(
+				new Request("http://localhost/users", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ name: "Alice" }),
+				}),
+			);
+
+			expect(response.status).toBe(200);
+			expect(await response.json()).toEqual({ name: "Alice" });
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds convenience body parsing methods to `RequestContext`, replacing the verbose `await ctx.request.json()` pattern with cleaner helpers.

Closes #51

## Changes

### New: Body parsing helpers on `RequestContext`

- **`ctx.json<T>()`** — Parse JSON body with type inference. Throws `BodyParseError` on malformed input.
- **`ctx.text()`** — Get request body as string (thin wrapper, no error wrapping needed).
- **`ctx.formData()`** — Parse multipart/URL-encoded form data. Throws `BodyParseError` on malformed input.

### New: `BodyParseError` class

Exported from `@bunary/http` so handlers can catch parse failures and return custom 400 responses:

```typescript
import { BodyParseError } from '@bunary/http';

app.post('/users', async (ctx) => {
  try {
    return await ctx.json();
  } catch (error) {
    if (error instanceof BodyParseError) {
      return new Response(JSON.stringify({ error: error.message }), { status: 400 });
    }
    throw error;
  }
});
```

### Internal: `createRequestContext()` factory

Centralises context construction so body helpers are available everywhere a `RequestContext` is built — including 404/405 handler contexts.

## Design decisions

- **Thin wrappers, not a parsing framework** — no validation, no schema, zero new dependencies
- **`BodyParseError` over auto-400** — handlers decide error responses, not the framework
- **Type parameter on `json<T>()`** — provides type inference without runtime validation (consistent with "explicit over magic")

## Testing

- 13 new tests covering happy path, error cases, typed generics, middleware interaction
- All 369 tests pass, lint clean, typecheck clean

## Version

`0.2.0` → `0.3.0` (minor bump for new API surface)