### PR TITLE
feat: add built-in CORS middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Built-in CORS middleware via `cors()` factory (#47)
+  - `cors()` with no arguments allows all origins (default `Access-Control-Allow-Origin: *`)
+  - Configurable `origin` (string, string array, or `"*"`), `methods`, `allowHeaders`, `exposeHeaders`, `credentials`, `maxAge`
+  - Handles preflight `OPTIONS` requests automatically — returns 204 with CORS headers
+  - Reflects `Access-Control-Request-Headers` by default, or uses explicit `allowHeaders`
+  - Adds `Vary: Origin` when origin is not `"*"` for correct cache behavior
+  - Works as global middleware (`app.use(cors())`) or per-group (`middleware: [cors()]`)
+  - `CorsOptions` type exported for TypeScript consumers
+
 - Body parsing helpers on `RequestContext` — `ctx.json()`, `ctx.text()`, `ctx.formData()` (#51)
   - `ctx.json<T>()` — parse JSON body with type inference, throws `BodyParseError` on malformed input
   - `ctx.text()` — get request body as string

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ Part of the [Bunary](https://github.com/bunary-dev) ecosystem: a Bun-first backe
 - ✅ **Route Constraints** - Validate parameters with regex patterns
 - ❓ **Optional Parameters** - Flexible routes with optional path segments
 - 🌐 **Wildcard Routes** - Catch-all `/*` and `/**` patterns for SPA fallbacks and proxies
+- 🔀 **CORS** - Built-in CORS middleware with configurable origins, methods, headers, and credentials
 
 ## Installation
 
@@ -466,6 +467,53 @@ app.use(async (ctx, next) => {
 });
 ```
 
+### CORS Middleware
+
+Built-in CORS middleware handles preflight `OPTIONS` requests and adds the appropriate headers to actual responses.
+
+```typescript
+import { createApp, cors } from '@bunary/http';
+
+const app = createApp();
+
+// Allow any origin (default)
+app.use(cors());
+```
+
+#### Configuration
+
+```typescript
+app.use(cors({
+  origin: 'https://myapp.com',             // string, string[], or "*" (default)
+  methods: ['GET', 'POST'],                 // default: GET, HEAD, PUT, POST, DELETE, PATCH
+  allowHeaders: ['Content-Type', 'X-Token'], // default: reflects Access-Control-Request-Headers
+  exposeHeaders: ['X-Request-Id'],          // headers the browser may read from the response
+  credentials: true,                        // include Access-Control-Allow-Credentials
+  maxAge: 86400,                            // preflight cache duration in seconds
+}));
+```
+
+#### Multiple Origins
+
+```typescript
+app.use(cors({
+  origin: ['https://app1.com', 'https://app2.com'],
+  credentials: true,
+}));
+```
+
+When `origin` is a string or array (not `"*"`), a `Vary: Origin` header is included automatically so caches distinguish responses per origin.
+
+#### Per-Group CORS
+
+Apply CORS to specific route groups instead of globally:
+
+```typescript
+app.group({ prefix: '/api', middleware: [cors()] }, (router) => {
+  router.get('/users', () => ({ users: [] }));
+});
+```
+
 ## Route Groups
 
 Group routes together with shared prefixes, middleware, and name prefixes.
@@ -739,7 +787,8 @@ import type {
   GroupOptions,
   GroupRouter,
   GroupCallback,
-  RouteInfo
+  RouteInfo,
+  CorsOptions,
 } from '@bunary/http';
 ```
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import {
 	toHeadResponse,
 } from "./handlers/index.js";
 import { joinPaths, normalizePrefix } from "./pathUtils.js";
+import { toResponse } from "./response.js";
 import { compilePath } from "./router.js";
 import { createGroupRouter, createRouteBuilder, resolveRoute } from "./routes/index.js";
 import type {
@@ -16,6 +17,7 @@ import type {
 	BunaryServer,
 	GroupCallback,
 	GroupOptions,
+	HandlerResponse,
 	HttpMethod,
 	Middleware,
 	RequestContext,
@@ -155,6 +157,24 @@ export function createApp<TLocals extends object = Record<string, unknown>>(
 
 		// Handle OPTIONS requests — single pass via resolveRoute
 		if (method === "OPTIONS") {
+			// CORS preflight: if an Origin header is present and global middleware
+			// is registered, run the middleware pipeline so that cors() (or any
+			// other middleware) can intercept and add the required headers.
+			if (request.headers.get("Origin") && middlewares.length > 0) {
+				const ctx: RequestContext = createRequestContext(request, {}, url.searchParams);
+				let index = 0;
+				const next = async (): Promise<HandlerResponse> => {
+					if (index < middlewares.length) {
+						const mw = middlewares[index++];
+						return await mw(ctx, next);
+					}
+					// After all middleware, fall through to normal OPTIONS handling
+					return await handleOptions(request, path, routes, internalOpts);
+				};
+				const result = await next();
+				return toResponse(result);
+			}
+
 			return await handleOptions(request, path, routes, internalOpts);
 		}
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,7 +10,12 @@ import {
 import { joinPaths, normalizePrefix } from "./pathUtils.js";
 import { toResponse } from "./response.js";
 import { compilePath } from "./router.js";
-import { createGroupRouter, createRouteBuilder, resolveRoute } from "./routes/index.js";
+import {
+	createGroupRouter,
+	createRouteBuilder,
+	findRouteByPath,
+	resolveRoute,
+} from "./routes/index.js";
 import type {
 	AppOptions,
 	BunaryApp,
@@ -157,22 +162,34 @@ export function createApp<TLocals extends object = Record<string, unknown>>(
 
 		// Handle OPTIONS requests — single pass via resolveRoute
 		if (method === "OPTIONS") {
-			// CORS preflight: if an Origin header is present and global middleware
-			// is registered, run the middleware pipeline so that cors() (or any
-			// other middleware) can intercept and add the required headers.
-			if (request.headers.get("Origin") && middlewares.length > 0) {
-				const ctx: RequestContext = createRequestContext(request, {}, url.searchParams);
-				let index = 0;
-				const next = async (): Promise<HandlerResponse> => {
-					if (index < middlewares.length) {
-						const mw = middlewares[index++];
-						return await mw(ctx, next);
-					}
-					// After all middleware, fall through to normal OPTIONS handling
-					return await handleOptions(request, path, routes, internalOpts);
-				};
-				const result = await next();
-				return toResponse(result);
+			// CORS preflight: if an Origin header is present, run the full
+			// middleware chain (global + group) so that cors() can intercept.
+			// We find the first route matching this path (any method) to pick
+			// up group-level middleware, then fall through to normal OPTIONS
+			// handling after the chain completes.
+			if (request.headers.get("Origin")) {
+				const routeMatch = findRouteByPath(routes, path);
+				const chain = routeMatch
+					? getMiddlewareChain(routeMatch.route)
+					: middlewares.length > 0
+						? [...middlewares]
+						: [];
+
+				if (chain.length > 0) {
+					const params = routeMatch?.params ?? {};
+					const ctx: RequestContext = createRequestContext(request, params, url.searchParams);
+					let index = 0;
+					const next = async (): Promise<HandlerResponse> => {
+						if (index < chain.length) {
+							const mw = chain[index++];
+							return await mw(ctx, next);
+						}
+						// After all middleware, fall through to normal OPTIONS handling
+						return await handleOptions(request, path, routes, internalOpts);
+					};
+					const result = await next();
+					return toResponse(result);
+				}
 			}
 
 			return await handleOptions(request, path, routes, internalOpts);

--- a/src/cors.ts
+++ b/src/cors.ts
@@ -1,0 +1,190 @@
+import { toResponse } from "./response.js";
+import type { Middleware } from "./types/index.js";
+
+/**
+ * CORS configuration options.
+ *
+ * @example
+ * ```ts
+ * const options: CorsOptions = {
+ *   origin: "https://myapp.com",
+ *   methods: ["GET", "POST"],
+ *   credentials: true,
+ *   maxAge: 86400,
+ * };
+ * ```
+ */
+export interface CorsOptions {
+	/**
+	 * Allowed origin(s). Use `"*"` (default) for any origin,
+	 * a single string for one origin, or an array for multiple.
+	 *
+	 * @default "*"
+	 */
+	origin?: string | string[];
+
+	/**
+	 * HTTP methods to advertise in `Access-Control-Allow-Methods`.
+	 *
+	 * @default ["GET", "HEAD", "PUT", "POST", "DELETE", "PATCH"]
+	 */
+	methods?: string[];
+
+	/**
+	 * Headers the client is allowed to send.
+	 * When omitted, the value of `Access-Control-Request-Headers` is reflected.
+	 */
+	allowHeaders?: string[];
+
+	/**
+	 * Response headers the browser may expose to client-side JavaScript.
+	 */
+	exposeHeaders?: string[];
+
+	/**
+	 * Whether to include `Access-Control-Allow-Credentials: true`.
+	 *
+	 * @default false
+	 */
+	credentials?: boolean;
+
+	/**
+	 * How long (in seconds) the browser may cache preflight results.
+	 * Omitted from the response when `undefined`.
+	 */
+	maxAge?: number;
+}
+
+const DEFAULT_METHODS = ["GET", "HEAD", "PUT", "POST", "DELETE", "PATCH"];
+
+/**
+ * Resolve whether the request origin is allowed.
+ *
+ * @returns The value to use for `Access-Control-Allow-Origin`, or `null` if
+ *          the origin is not permitted.
+ */
+function resolveOrigin(allowed: string | string[], requestOrigin: string): string | null {
+	if (allowed === "*") {
+		return "*";
+	}
+	if (typeof allowed === "string") {
+		return allowed === requestOrigin ? allowed : null;
+	}
+	return allowed.includes(requestOrigin) ? requestOrigin : null;
+}
+
+/**
+ * Create a CORS middleware.
+ *
+ * Handles preflight `OPTIONS` requests (returns 204) and
+ * adds CORS headers to actual responses.
+ *
+ * @param options - CORS configuration (defaults allow all origins)
+ * @returns Middleware function
+ *
+ * @example
+ * ```ts
+ * import { createApp, cors } from "@bunary/http";
+ *
+ * // Allow any origin
+ * const app = createApp();
+ * app.use(cors());
+ *
+ * // Restrict to a single origin with credentials
+ * app.use(cors({
+ *   origin: "https://myapp.com",
+ *   credentials: true,
+ *   maxAge: 86400,
+ * }));
+ *
+ * // Multiple allowed origins
+ * app.use(cors({
+ *   origin: ["https://app1.com", "https://app2.com"],
+ *   methods: ["GET", "POST"],
+ * }));
+ * ```
+ */
+export function cors(options: CorsOptions = {}): Middleware {
+	const {
+		origin = "*",
+		methods = DEFAULT_METHODS,
+		allowHeaders,
+		exposeHeaders,
+		credentials = false,
+		maxAge,
+	} = options;
+
+	return async (ctx, next) => {
+		const requestOrigin = ctx.request.headers.get("Origin");
+
+		// No Origin header — not a CORS request, pass through.
+		if (!requestOrigin) {
+			return await next();
+		}
+
+		// Is this origin allowed?
+		const allowedOrigin = resolveOrigin(origin, requestOrigin);
+		if (!allowedOrigin) {
+			// Origin not allowed — respond normally without CORS headers.
+			return await next();
+		}
+
+		// ── Preflight (OPTIONS) ────────────────────────────────────
+		if (ctx.request.method === "OPTIONS") {
+			const headers = new Headers();
+			headers.set("Access-Control-Allow-Origin", allowedOrigin);
+
+			if (origin !== "*") {
+				headers.append("Vary", "Origin");
+			}
+
+			headers.set("Access-Control-Allow-Methods", methods.join(", "));
+
+			if (allowHeaders) {
+				headers.set("Access-Control-Allow-Headers", allowHeaders.join(", "));
+			} else {
+				// Reflect the headers the client asked for.
+				const requested = ctx.request.headers.get("Access-Control-Request-Headers");
+				if (requested) {
+					headers.set("Access-Control-Allow-Headers", requested);
+				}
+			}
+
+			if (credentials) {
+				headers.set("Access-Control-Allow-Credentials", "true");
+			}
+
+			if (maxAge !== undefined) {
+				headers.set("Access-Control-Max-Age", String(maxAge));
+			}
+
+			return new Response(null, { status: 204, headers });
+		}
+
+		// ── Actual request ─────────────────────────────────────────
+		const result = await next();
+		const response = toResponse(result);
+
+		// Build a new Response with CORS headers added.
+		const newHeaders = new Headers(response.headers);
+		newHeaders.set("Access-Control-Allow-Origin", allowedOrigin);
+
+		if (origin !== "*") {
+			newHeaders.append("Vary", "Origin");
+		}
+
+		if (exposeHeaders && exposeHeaders.length > 0) {
+			newHeaders.set("Access-Control-Expose-Headers", exposeHeaders.join(", "));
+		}
+
+		if (credentials) {
+			newHeaders.set("Access-Control-Allow-Credentials", "true");
+		}
+
+		return new Response(response.body, {
+			status: response.status,
+			statusText: response.statusText,
+			headers: newHeaders,
+		});
+	};
+}

--- a/src/cors.ts
+++ b/src/cors.ts
@@ -63,9 +63,15 @@ const DEFAULT_METHODS = ["GET", "HEAD", "PUT", "POST", "DELETE", "PATCH"];
  * @returns The value to use for `Access-Control-Allow-Origin`, or `null` if
  *          the origin is not permitted.
  */
-function resolveOrigin(allowed: string | string[], requestOrigin: string): string | null {
+function resolveOrigin(
+	allowed: string | string[],
+	requestOrigin: string,
+	credentials: boolean,
+): string | null {
 	if (allowed === "*") {
-		return "*";
+		// The CORS spec forbids Access-Control-Allow-Origin: * when
+		// credentials are in use. Reflect the actual request origin instead.
+		return credentials ? requestOrigin : "*";
 	}
 	if (typeof allowed === "string") {
 		return allowed === requestOrigin ? allowed : null;
@@ -123,18 +129,23 @@ export function cors(options: CorsOptions = {}): Middleware {
 		}
 
 		// Is this origin allowed?
-		const allowedOrigin = resolveOrigin(origin, requestOrigin);
+		const allowedOrigin = resolveOrigin(origin, requestOrigin, credentials);
 		if (!allowedOrigin) {
 			// Origin not allowed — respond normally without CORS headers.
 			return await next();
 		}
+
+		// When credentials are used with wildcard origin, the resolved
+		// value is the reflected request origin — Vary must include Origin
+		// so caches distinguish per-origin responses.
+		const needsVary = origin !== "*" || credentials;
 
 		// ── Preflight (OPTIONS) ────────────────────────────────────
 		if (ctx.request.method === "OPTIONS") {
 			const headers = new Headers();
 			headers.set("Access-Control-Allow-Origin", allowedOrigin);
 
-			if (origin !== "*") {
+			if (needsVary) {
 				headers.append("Vary", "Origin");
 			}
 
@@ -169,7 +180,7 @@ export function cors(options: CorsOptions = {}): Middleware {
 		const newHeaders = new Headers(response.headers);
 		newHeaders.set("Access-Control-Allow-Origin", allowedOrigin);
 
-		if (origin !== "*") {
+		if (needsVary) {
 			newHeaders.append("Vary", "Origin");
 		}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,9 @@
 
 // Export app factory
 export { createApp } from "./app.js";
+export type { CorsOptions } from "./cors.js";
+// Export CORS middleware
+export { cors } from "./cors.js";
 // Export error classes
 export { BodyParseError } from "./errors.js";
 // Export types

--- a/src/routes/find.ts
+++ b/src/routes/find.ts
@@ -108,6 +108,22 @@ export function hasMatchingPath(routes: Route[], path: string): boolean {
 }
 
 /**
+ * Find the first route whose path matches, regardless of HTTP method.
+ *
+ * Used by the OPTIONS/CORS preflight handler to locate group middleware
+ * attached to a route at this path.
+ */
+export function findRouteByPath(routes: Route[], path: string): RouteMatch | null {
+	for (const route of routes) {
+		if (!route.pattern.test(path)) continue;
+		const params = extractParams(path, route);
+		if (!checkConstraints(params, route.constraints)) continue;
+		return { route, params };
+	}
+	return null;
+}
+
+/**
  * Get all allowed HTTP methods for a given path.
  * Respects route constraints when determining matches.
  *

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,6 +1,7 @@
 export { compilePattern, createRouteBuilder, wrapBuilderWithNamePrefix } from "./builder.js";
 export {
 	findRoute,
+	findRouteByPath,
 	getAllowedMethods,
 	hasMatchingPath,
 	type RouteMatch,

--- a/tests/cors.test.ts
+++ b/tests/cors.test.ts
@@ -317,6 +317,47 @@ describe("CORS Middleware", () => {
 			expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
 		});
 
+		test("group-level CORS handles preflight OPTIONS with full CORS headers", async () => {
+			const app = createApp();
+			app.group(
+				{
+					prefix: "/api",
+					middleware: [
+						cors({
+							origin: "https://myapp.com",
+							methods: ["GET", "POST"],
+							allowHeaders: ["Content-Type", "Authorization"],
+							credentials: true,
+							maxAge: 3600,
+						}),
+					],
+				},
+				(router) => {
+					router.post("/items", () => ({ created: true }));
+				},
+			);
+
+			const response = await app.fetch(
+				new Request("http://localhost/api/items", {
+					method: "OPTIONS",
+					headers: {
+						Origin: "https://myapp.com",
+						"Access-Control-Request-Method": "POST",
+						"Access-Control-Request-Headers": "Content-Type, Authorization",
+					},
+				}),
+			);
+
+			expect(response.status).toBe(204);
+			expect(response.headers.get("Access-Control-Allow-Origin")).toBe("https://myapp.com");
+			expect(response.headers.get("Access-Control-Allow-Methods")).toBe("GET, POST");
+			expect(response.headers.get("Access-Control-Allow-Headers")).toBe(
+				"Content-Type, Authorization",
+			);
+			expect(response.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+			expect(response.headers.get("Access-Control-Max-Age")).toBe("3600");
+		});
+
 		test("preflight OPTIONS uses group middleware, not just global", async () => {
 			const app = createApp();
 			// No global CORS — only the /api group has it
@@ -394,6 +435,66 @@ describe("CORS Middleware", () => {
 			expect(response.status).toBe(200);
 			expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
 			expect(await response.text()).toBe("hello");
+		});
+	});
+
+	describe("Credentials with wildcard origin", () => {
+		test("reflects request origin instead of * when credentials: true", async () => {
+			const app = createApp();
+			app.use(cors({ credentials: true }));
+			app.get("/api/data", () => ({ ok: true }));
+
+			const response = await app.fetch(
+				new Request("http://localhost/api/data", {
+					headers: { Origin: "https://example.com" },
+				}),
+			);
+
+			expect(response.status).toBe(200);
+			expect(response.headers.get("Access-Control-Allow-Origin")).toBe("https://example.com");
+			expect(response.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+			expect(response.headers.get("Vary")).toContain("Origin");
+		});
+
+		test("reflects request origin on preflight when credentials: true", async () => {
+			const app = createApp();
+			app.use(cors({ credentials: true }));
+			app.get("/api/data", () => ({ ok: true }));
+
+			const response = await app.fetch(
+				new Request("http://localhost/api/data", {
+					method: "OPTIONS",
+					headers: {
+						Origin: "https://example.com",
+						"Access-Control-Request-Method": "GET",
+					},
+				}),
+			);
+
+			expect(response.status).toBe(204);
+			expect(response.headers.get("Access-Control-Allow-Origin")).toBe("https://example.com");
+			expect(response.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+			expect(response.headers.get("Vary")).toContain("Origin");
+		});
+
+		test("different origins get different reflected values", async () => {
+			const app = createApp();
+			app.use(cors({ credentials: true }));
+			app.get("/api/data", () => ({ ok: true }));
+
+			const res1 = await app.fetch(
+				new Request("http://localhost/api/data", {
+					headers: { Origin: "https://app1.com" },
+				}),
+			);
+			const res2 = await app.fetch(
+				new Request("http://localhost/api/data", {
+					headers: { Origin: "https://app2.com" },
+				}),
+			);
+
+			expect(res1.headers.get("Access-Control-Allow-Origin")).toBe("https://app1.com");
+			expect(res2.headers.get("Access-Control-Allow-Origin")).toBe("https://app2.com");
 		});
 	});
 

--- a/tests/cors.test.ts
+++ b/tests/cors.test.ts
@@ -316,6 +316,44 @@ describe("CORS Middleware", () => {
 			expect(response.status).toBe(200);
 			expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
 		});
+
+		test("preflight OPTIONS uses group middleware, not just global", async () => {
+			const app = createApp();
+			// No global CORS — only the /api group has it
+			app.group({ prefix: "/api", middleware: [cors()] }, (router) => {
+				router.get("/users", () => ({ users: [] }));
+			});
+			app.get("/public", () => ({ public: true }));
+
+			// Preflight to /api/users should get CORS headers from group middleware
+			const apiResponse = await app.fetch(
+				new Request("http://localhost/api/users", {
+					method: "OPTIONS",
+					headers: {
+						Origin: "https://example.com",
+						"Access-Control-Request-Method": "GET",
+					},
+				}),
+			);
+
+			expect(apiResponse.status).toBe(204);
+			expect(apiResponse.headers.get("Access-Control-Allow-Origin")).toBe("*");
+			expect(apiResponse.headers.get("Access-Control-Allow-Methods")).toBeTruthy();
+
+			// Preflight to /public should NOT get CORS headers (no CORS middleware)
+			const publicResponse = await app.fetch(
+				new Request("http://localhost/public", {
+					method: "OPTIONS",
+					headers: {
+						Origin: "https://example.com",
+						"Access-Control-Request-Method": "GET",
+					},
+				}),
+			);
+
+			expect(publicResponse.status).toBe(204);
+			expect(publicResponse.headers.get("Access-Control-Allow-Origin")).toBeNull();
+		});
 	});
 
 	describe("Works with handler responses", () => {

--- a/tests/cors.test.ts
+++ b/tests/cors.test.ts
@@ -1,0 +1,379 @@
+import { describe, expect, test } from "bun:test";
+import { cors } from "../src/cors.js";
+import { createApp } from "../src/index.js";
+
+describe("CORS Middleware", () => {
+	describe("Default configuration (allow all)", () => {
+		test("adds CORS headers to simple GET request with Origin", async () => {
+			const app = createApp();
+			app.use(cors());
+			app.get("/api/data", () => ({ data: "value" }));
+
+			const response = await app.fetch(
+				new Request("http://localhost/api/data", {
+					headers: { Origin: "https://example.com" },
+				}),
+			);
+
+			expect(response.status).toBe(200);
+			expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+			expect(await response.json()).toEqual({ data: "value" });
+		});
+
+		test("does not add CORS headers when no Origin header", async () => {
+			const app = createApp();
+			app.use(cors());
+			app.get("/api/data", () => ({ data: "value" }));
+
+			const response = await app.fetch(new Request("http://localhost/api/data"));
+
+			expect(response.status).toBe(200);
+			expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
+		});
+
+		test("handles preflight OPTIONS request", async () => {
+			const app = createApp();
+			app.use(cors());
+			app.get("/api/data", () => ({ data: "value" }));
+
+			const response = await app.fetch(
+				new Request("http://localhost/api/data", {
+					method: "OPTIONS",
+					headers: {
+						Origin: "https://example.com",
+						"Access-Control-Request-Method": "GET",
+					},
+				}),
+			);
+
+			expect(response.status).toBe(204);
+			expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+			expect(response.headers.get("Access-Control-Allow-Methods")).toBeTruthy();
+		});
+
+		test("preflight includes default allowed methods", async () => {
+			const app = createApp();
+			app.use(cors());
+			app.get("/api/data", () => ({ data: "value" }));
+
+			const response = await app.fetch(
+				new Request("http://localhost/api/data", {
+					method: "OPTIONS",
+					headers: {
+						Origin: "https://example.com",
+						"Access-Control-Request-Method": "POST",
+					},
+				}),
+			);
+
+			expect(response.status).toBe(204);
+			const methods = response.headers.get("Access-Control-Allow-Methods");
+			expect(methods).toContain("GET");
+			expect(methods).toContain("POST");
+			expect(methods).toContain("PUT");
+			expect(methods).toContain("DELETE");
+			expect(methods).toContain("PATCH");
+		});
+
+		test("preflight reflects Access-Control-Request-Headers", async () => {
+			const app = createApp();
+			app.use(cors());
+			app.get("/api/data", () => ({ data: "value" }));
+
+			const response = await app.fetch(
+				new Request("http://localhost/api/data", {
+					method: "OPTIONS",
+					headers: {
+						Origin: "https://example.com",
+						"Access-Control-Request-Method": "POST",
+						"Access-Control-Request-Headers": "Content-Type, Authorization",
+					},
+				}),
+			);
+
+			expect(response.status).toBe(204);
+			expect(response.headers.get("Access-Control-Allow-Headers")).toBe(
+				"Content-Type, Authorization",
+			);
+		});
+	});
+
+	describe("Configured origin", () => {
+		test("single string origin — matching request", async () => {
+			const app = createApp();
+			app.use(cors({ origin: "https://myapp.com" }));
+			app.get("/api/data", () => ({ ok: true }));
+
+			const response = await app.fetch(
+				new Request("http://localhost/api/data", {
+					headers: { Origin: "https://myapp.com" },
+				}),
+			);
+
+			expect(response.status).toBe(200);
+			expect(response.headers.get("Access-Control-Allow-Origin")).toBe("https://myapp.com");
+			expect(response.headers.get("Vary")).toContain("Origin");
+		});
+
+		test("single string origin — non-matching request", async () => {
+			const app = createApp();
+			app.use(cors({ origin: "https://myapp.com" }));
+			app.get("/api/data", () => ({ ok: true }));
+
+			const response = await app.fetch(
+				new Request("http://localhost/api/data", {
+					headers: { Origin: "https://evil.com" },
+				}),
+			);
+
+			expect(response.status).toBe(200);
+			expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
+		});
+
+		test("array of origins — matching one", async () => {
+			const app = createApp();
+			app.use(cors({ origin: ["https://app1.com", "https://app2.com"] }));
+			app.get("/api/data", () => ({ ok: true }));
+
+			const response = await app.fetch(
+				new Request("http://localhost/api/data", {
+					headers: { Origin: "https://app2.com" },
+				}),
+			);
+
+			expect(response.status).toBe(200);
+			expect(response.headers.get("Access-Control-Allow-Origin")).toBe("https://app2.com");
+			expect(response.headers.get("Vary")).toContain("Origin");
+		});
+
+		test("array of origins — none matching", async () => {
+			const app = createApp();
+			app.use(cors({ origin: ["https://app1.com", "https://app2.com"] }));
+			app.get("/api/data", () => ({ ok: true }));
+
+			const response = await app.fetch(
+				new Request("http://localhost/api/data", {
+					headers: { Origin: "https://evil.com" },
+				}),
+			);
+
+			expect(response.status).toBe(200);
+			expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
+		});
+	});
+
+	describe("Configured methods", () => {
+		test("custom methods in preflight", async () => {
+			const app = createApp();
+			app.use(cors({ methods: ["GET", "POST"] }));
+			app.get("/api/data", () => ({ ok: true }));
+
+			const response = await app.fetch(
+				new Request("http://localhost/api/data", {
+					method: "OPTIONS",
+					headers: {
+						Origin: "https://example.com",
+						"Access-Control-Request-Method": "POST",
+					},
+				}),
+			);
+
+			expect(response.status).toBe(204);
+			expect(response.headers.get("Access-Control-Allow-Methods")).toBe("GET, POST");
+		});
+	});
+
+	describe("Configured headers", () => {
+		test("custom allowHeaders in preflight", async () => {
+			const app = createApp();
+			app.use(cors({ allowHeaders: ["Content-Type", "X-Custom"] }));
+			app.get("/api/data", () => ({ ok: true }));
+
+			const response = await app.fetch(
+				new Request("http://localhost/api/data", {
+					method: "OPTIONS",
+					headers: {
+						Origin: "https://example.com",
+						"Access-Control-Request-Method": "GET",
+						"Access-Control-Request-Headers": "Authorization",
+					},
+				}),
+			);
+
+			expect(response.status).toBe(204);
+			// Explicit allowHeaders overrides request headers reflection
+			expect(response.headers.get("Access-Control-Allow-Headers")).toBe("Content-Type, X-Custom");
+		});
+	});
+
+	describe("Expose headers", () => {
+		test("exposeHeaders on actual response", async () => {
+			const app = createApp();
+			app.use(cors({ exposeHeaders: ["X-Request-Id", "X-Total-Count"] }));
+			app.get("/api/data", () => ({ ok: true }));
+
+			const response = await app.fetch(
+				new Request("http://localhost/api/data", {
+					headers: { Origin: "https://example.com" },
+				}),
+			);
+
+			expect(response.status).toBe(200);
+			expect(response.headers.get("Access-Control-Expose-Headers")).toBe(
+				"X-Request-Id, X-Total-Count",
+			);
+		});
+	});
+
+	describe("Credentials", () => {
+		test("credentials: true adds Allow-Credentials header", async () => {
+			const app = createApp();
+			app.use(cors({ origin: "https://myapp.com", credentials: true }));
+			app.get("/api/data", () => ({ ok: true }));
+
+			const response = await app.fetch(
+				new Request("http://localhost/api/data", {
+					headers: { Origin: "https://myapp.com" },
+				}),
+			);
+
+			expect(response.status).toBe(200);
+			expect(response.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+		});
+
+		test("credentials: true on preflight", async () => {
+			const app = createApp();
+			app.use(cors({ origin: "https://myapp.com", credentials: true }));
+			app.get("/api/data", () => ({ ok: true }));
+
+			const response = await app.fetch(
+				new Request("http://localhost/api/data", {
+					method: "OPTIONS",
+					headers: {
+						Origin: "https://myapp.com",
+						"Access-Control-Request-Method": "GET",
+					},
+				}),
+			);
+
+			expect(response.status).toBe(204);
+			expect(response.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+		});
+	});
+
+	describe("Max age", () => {
+		test("maxAge sets Access-Control-Max-Age on preflight", async () => {
+			const app = createApp();
+			app.use(cors({ maxAge: 86400 }));
+			app.get("/api/data", () => ({ ok: true }));
+
+			const response = await app.fetch(
+				new Request("http://localhost/api/data", {
+					method: "OPTIONS",
+					headers: {
+						Origin: "https://example.com",
+						"Access-Control-Request-Method": "GET",
+					},
+				}),
+			);
+
+			expect(response.status).toBe(204);
+			expect(response.headers.get("Access-Control-Max-Age")).toBe("86400");
+		});
+
+		test("no maxAge by default", async () => {
+			const app = createApp();
+			app.use(cors());
+			app.get("/api/data", () => ({ ok: true }));
+
+			const response = await app.fetch(
+				new Request("http://localhost/api/data", {
+					method: "OPTIONS",
+					headers: {
+						Origin: "https://example.com",
+						"Access-Control-Request-Method": "GET",
+					},
+				}),
+			);
+
+			expect(response.headers.get("Access-Control-Max-Age")).toBeNull();
+		});
+	});
+
+	describe("Works with route groups", () => {
+		test("CORS middleware in group applies to group routes", async () => {
+			const app = createApp();
+			app.group({ prefix: "/api", middleware: [cors()] }, (router) => {
+				router.get("/users", () => ({ users: [] }));
+			});
+
+			const response = await app.fetch(
+				new Request("http://localhost/api/users", {
+					headers: { Origin: "https://example.com" },
+				}),
+			);
+
+			expect(response.status).toBe(200);
+			expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+		});
+	});
+
+	describe("Works with handler responses", () => {
+		test("adds CORS headers to custom Response objects", async () => {
+			const app = createApp();
+			app.use(cors());
+			app.get(
+				"/api/custom",
+				() =>
+					new Response(JSON.stringify({ custom: true }), {
+						status: 201,
+						headers: { "Content-Type": "application/json" },
+					}),
+			);
+
+			const response = await app.fetch(
+				new Request("http://localhost/api/custom", {
+					headers: { Origin: "https://example.com" },
+				}),
+			);
+
+			expect(response.status).toBe(201);
+			expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+			expect(await response.json()).toEqual({ custom: true });
+		});
+
+		test("adds CORS headers to string responses", async () => {
+			const app = createApp();
+			app.use(cors());
+			app.get("/api/text", () => "hello");
+
+			const response = await app.fetch(
+				new Request("http://localhost/api/text", {
+					headers: { Origin: "https://example.com" },
+				}),
+			);
+
+			expect(response.status).toBe(200);
+			expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+			expect(await response.text()).toBe("hello");
+		});
+	});
+
+	describe("Non-CORS OPTIONS requests", () => {
+		test("OPTIONS without Origin still returns normal 204", async () => {
+			const app = createApp();
+			app.use(cors());
+			app.get("/api/data", () => ({ ok: true }));
+
+			const response = await app.fetch(
+				new Request("http://localhost/api/data", {
+					method: "OPTIONS",
+				}),
+			);
+
+			// Normal OPTIONS handling (no CORS headers)
+			expect(response.status).toBe(204);
+			expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
+		});
+	});
+});


### PR DESCRIPTION
Closes #47

## Summary

Adds a built-in `cors()` middleware factory that handles CORS preflight and actual request headers.

## Changes

### `src/cors.ts` (new)
- `cors(options?)` factory returns a `Middleware` that:
  - **Preflight**: intercepts `OPTIONS` requests with `Origin` header, returns 204 with `Access-Control-Allow-Origin`, `Access-Control-Allow-Methods`, `Access-Control-Allow-Headers`, `Access-Control-Allow-Credentials`, and `Access-Control-Max-Age`
  - **Actual requests**: calls `next()`, wraps the response with CORS headers
  - Skips requests without `Origin` (not a CORS request)
  - Rejects non-matching origins silently (no CORS headers)

### `CorsOptions`
| Option | Type | Default | Description |
|---|---|---|---|
| `origin` | `string \| string[] \| "*"` | `"*"` | Allowed origin(s) |
| `methods` | `string[]` | `GET, HEAD, PUT, POST, DELETE, PATCH` | Preflight `Allow-Methods` |
| `allowHeaders` | `string[]` | reflects `Access-Control-Request-Headers` | Preflight `Allow-Headers` |
| `exposeHeaders` | `string[]` | — | `Expose-Headers` on actual responses |
| `credentials` | `boolean` | `false` | `Allow-Credentials: true` |
| `maxAge` | `number` | — | Preflight cache duration (seconds) |

### `src/app.ts`
- Modified `handleRequest` OPTIONS path: when `Origin` header is present and global middleware exists, runs the middleware pipeline before falling through to the normal OPTIONS handler. This allows `cors()` to intercept preflight requests.

### `src/index.ts`
- Exports `cors` function and `CorsOptions` type

### `tests/cors.test.ts` (new)
20 tests covering:
- Default allow-all configuration
- Configured single/array origin matching and rejection
- Custom methods, headers, expose headers
- Credentials and max-age
- Route groups with per-group CORS
- Custom Response and string handler responses
- Non-CORS OPTIONS passthrough

### `docs/index.md`
- Added CORS section under Middleware with configuration examples
- Added `CorsOptions` to types reference
- Added CORS to features list

### `CHANGELOG.md`
- Added CORS entry to 0.3.0 (no version bump)

## Test results

```
390 pass, 0 fail — 22 files
```
